### PR TITLE
Fixes wrong height for views of different height within a section of a scrollview

### DIFF
--- a/Swipy/Swipy.swift
+++ b/Swipy/Swipy.swift
@@ -226,7 +226,6 @@ public struct Swipy<C, A>: View where C: View, A: View {
                         )
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
 
             GeometryReader { geometry in
                 HStack(spacing: 0) {
@@ -243,7 +242,6 @@ public struct Swipy<C, A>: View where C: View, A: View {
                             .onChange(of: geometry.size.width) { newValue in model.swipeActionsWidth = newValue }
                     }
                 )
-                .frame(height: (model.contentSize ?? geometry.size).height)
                 .offset(x: (model.contentSize ?? geometry.size).width)
             }
         }


### PR DESCRIPTION
I am using this library for a contact list (scrollview). The views are grouped into sections alphabetically. The height of each contact view can be different, as there are shorter and longer names. So within one section there might be a view where the name fits into a single line, another view might need two or more lines to display the name.
In this case (views with different heights in one section) every text view within the contact views gets limited to a single line. Also the width of the swipe action button is too small.

This is the behavior i am experiencing:
<img width="301" height="590" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-05 at 15 59 42" src="https://github.com/user-attachments/assets/b8f28fe0-b879-481f-9e0a-69c7e5658631" />
<img width="301" height="590" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-05 at 15 59 49" src="https://github.com/user-attachments/assets/4ad404a6-8f73-4d22-a445-0959969037f5" />

I dont know why these two lines i deleted are necessary in the first place. Without them it works fine